### PR TITLE
Removed sdmmc2 node from starterkit dtb for iCoreST

### DIFF
--- a/arch/arm/boot/dts/stm32mp157a-icorestm32-lvds-mx.dts
+++ b/arch/arm/boot/dts/stm32mp157a-icorestm32-lvds-mx.dts
@@ -436,32 +436,6 @@
             slew-rate = <3>;
         };
     };
-    sdmmc2_pins_mx: sdmmc2_mx-0 {
-        u-boot,dm-pre-reloc;
-        pins1 {
-            u-boot,dm-pre-reloc;
-					pinmux = <STM32_PINMUX('B', 14, AF9)>, /* SDMMC2_D0 */
-						 <STM32_PINMUX('B', 15, AF9)>, /* SDMMC2_D1 */
-						 <STM32_PINMUX('B', 3, AF9)>, /* SDMMC2_D2 */
-						 <STM32_PINMUX('B', 4, AF9)>, /* SDMMC2_D3 */
-						 <STM32_PINMUX('E', 3, AF9)>, /* SDMMC2_CK */
-						 <STM32_PINMUX('G', 6, AF10)>, /* SDMMC2_CMD */
-						 <STM32_PINMUX('A', 8, AF9)>, /* SDMMC2_D4 */
-						 <STM32_PINMUX('A', 9, AF10)>, /* SDMMC2_D5 */
-						 <STM32_PINMUX('E', 5, AF9)>, /* SDMMC2_D6 */
-						 <STM32_PINMUX('D', 3, AF9)>; /* SDMMC2_D7 */
-					slew-rate = <3>;
-					drive-push-pull;
-					bias-pull-up;
-        };
-        pins2 {
-            u-boot,dm-pre-reloc;
-            pinmux = <STM32_PINMUX('E', 3, AF9)>; /* SDMMC2_CK */
-            bias-disable;
-            drive-push-pull;
-            slew-rate = <3>;
-        };
-    };
     sdmmc3_pins_mx: sdmmc3_mx-0 {
         u-boot,dm-pre-reloc;
         pins1 {
@@ -608,22 +582,6 @@
                      <STM32_PINMUX('C', 11, ANALOG)>, /* SDMMC1_D3 */
                      <STM32_PINMUX('C', 12, ANALOG)>, /* SDMMC1_CK */
                      <STM32_PINMUX('D', 2, ANALOG)>; /* SDMMC1_CMD */
-        };
-    };
-    sdmmc2_sleep_pins_mx: sdmmc2_sleep_mx-0 {
-        u-boot,dm-pre-reloc;
-        pins {
-            u-boot,dm-pre-reloc;
-            pinmux = <STM32_PINMUX('A', 8, ANALOG)>, /* SDMMC2_D4 */
-                     <STM32_PINMUX('A', 9, ANALOG)>, /* SDMMC2_D5 */
-                     <STM32_PINMUX('B', 3, ANALOG)>, /* SDMMC2_D2 */
-                     <STM32_PINMUX('B', 4, ANALOG)>, /* SDMMC2_D3 */
-                     <STM32_PINMUX('B', 14, ANALOG)>, /* SDMMC2_D0 */
-                     <STM32_PINMUX('B', 15, ANALOG)>, /* SDMMC2_D1 */
-                     <STM32_PINMUX('D', 3, ANALOG)>, /* SDMMC2_D7 */
-                     <STM32_PINMUX('E', 3, ANALOG)>, /* SDMMC2_CK */
-                     <STM32_PINMUX('E', 5, ANALOG)>, /* SDMMC2_D6 */
-                     <STM32_PINMUX('G', 6, ANALOG)>; /* SDMMC2_CMD */
         };
     };
     uart4_sleep_pins_mx: uart4_sleep_mx-0 {
@@ -1033,25 +991,6 @@
 	max-frequency = <10000000>;
 	vmmc-supply = <&v3v3>;
     /* USER CODE END sdmmc1 */
-};
-
-&sdmmc2{
-    u-boot,dm-pre-reloc;
-    pinctrl-names = "default", "sleep";
-    pinctrl-0 = <&sdmmc2_pins_mx>;
-    pinctrl-1 = <&sdmmc2_sleep_pins_mx>;
-    status = "okay";
-
-    /* USER CODE BEGIN sdmmc2 */  
-    non-removable;
-	no-sd;
-	no-sdio;
-	st,dirpol;
-	st,negedge;
-	bus-width = <8>;
-	vmmc-supply = <&v3v3>;
-	vqmmc-supply = <&v3v3>;
-    /* USER CODE END sdmmc2 */
 };
 
 &sdmmc3{


### PR DESCRIPTION
there is no sdmmc2 for icoreST 