### PR TITLE
ohci controller fix for usb

### DIFF
--- a/arch/arm/boot/dts/stm32mp157a-ugeast-mx.dts
+++ b/arch/arm/boot/dts/stm32mp157a-ugeast-mx.dts
@@ -779,6 +779,12 @@
 	status = "okay";
 };
 
+&usbh_ohci {
+	phys = <&usbphyc_port0>;
+	phy-names = "usb";
+	status = "okay";
+};
+
 &usbotg_hs {
 	dr_mode = "host";
 	force-b-session-valid;


### PR DESCRIPTION
After building the engicam-test-hw with your latest BSP VM I found out that my USB OHCI device was not being enumerated anymore. I checked your meta-engicam-st repository to see that this was already fixed in the master branch (commit 33f29e76c6b29a9c14cef029a679ab0689697884), but it was not ported into the thud branch. I applied the fix and my USB OHCI device is now working as it was before with the old BSP. 
This seems to me the right place to apply the fix, since the meta-engicam-st layer is pointing here right now, but correct me if I am wrong.